### PR TITLE
MariaDB: Scripts to start, stop server. lc_messages_dir no longer needed

### DIFF
--- a/notes/3.SetupDatabaseServer.md
+++ b/notes/3.SetupDatabaseServer.md
@@ -11,7 +11,7 @@
    ```
    *mysql_install_db*  
    Initialises MariaDB data directory and creates default system tables.  
-   
+
    *--defaults-file*  
    Specifies a custom option file.  
    MariaDB disregards default option files e.g. /etc/my.cnf, ~/.my.cnf, etc.  
@@ -40,5 +40,17 @@
    Remove test database and access to it? [Y/n] Y
    Reload privilege tables now? [Y/n] Y
    ```
+
+   1. Create a file in your home directory: ``~/.my.cnf` to add your root credentials - use the password you specified in the previous step, use 'gedit' or 'nano' if you prefer instead of 'vim':
+      ```bash
+      vim ~/.my.cnf
+      ```
+      Add the following lines, then save and exit:
+      ```
+      [client]
+      user=root
+      password="the password"
+      !includedir=/scratch/SynchWebDevEnvWS/server/mariadb
+      ```
 
 1. Next : [Setup ISPyB](./4.SetupISPyB.md)

--- a/notes/6.ControlServers.md
+++ b/notes/6.ControlServers.md
@@ -5,7 +5,7 @@
 
    ```
    $ module load mariadb-server
-   $ mysqld --defaults-file=/scratch/SynchWebDevEnvWS/server/mariadb/my.cnf &
+   $ /scratch/SynchWebDevEnvWS/server/mariadb/bin/start.sh
    $ php-fpm --fpm-config /scratch/SynchWebDevEnvWS/server/php-fpm/php-fpm.conf -c /scratch/SynchWebDevEnvWS/server/php-fpm/php.ini
    $ httpd -f /scratch/SynchWebDevEnvWS/server/httpd/conf/httpd.conf -k start
    ```
@@ -35,4 +35,6 @@
    $ pkill php-fpm
    $ module load mariadb-server
    $ mysqladmin shutdown --host=127.0.0.1 --user=root
+   # ... or alternatively:
+   $ /scratch/SynchWebDevEnvWS/server/mariadb/bin/stop.sh
    ```

--- a/server/mariadb/bin/start.sh
+++ b/server/mariadb/bin/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mysqld --defaults-file=/scratch/SynchWebDevEnvWS/server/mariadb/my.cnf --basedir=$MARIADB_HOME &
+

--- a/server/mariadb/bin/stop.sh
+++ b/server/mariadb/bin/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mysql --defaults-extra-file=/scratch/SynchWebDevEnvWS/server/mariadb/my.cnf --defaults-group-suffix=`hostname -s` -uroot -e "SHUTDOWN"

--- a/server/mariadb/my.cnf
+++ b/server/mariadb/my.cnf
@@ -12,7 +12,7 @@ skip-character-set-client-handshake # Ensures collation_connection is utf8_unico
 datadir = /scratch/SynchWebDevEnvWS/server/mariadb/data
 default-time-zone = +00:00 # UTC/GMT
 open_files_limit = 4096
-lc_messages_dir = /dls_sw/dasc/mariadb-server/10.3.10/share/english
+lc_messages = en_GB # Other common options: fr_FR, de_DE, en_US, nb_NO
 
 # Enable networking but bind to local for remote access by SSH only
 bind-address = 127.0.0.1


### PR DESCRIPTION
- Added convenience scripts to start and stop the MariaDB server.
- `lc_messages_dir` should not be needed if you specify the `basedir` cmd line parameter.
- Use `lc_messages` to specify language.
- Updated instructions about creating a `~/.my.cnf` file for credentials.
- Updated instructions to explain use of `start.sh` and `stop.sh` in `server/mariadb/bin/`.